### PR TITLE
Add hero banner to timeline page

### DIFF
--- a/frontend/src/components/HeroBanner.tsx
+++ b/frontend/src/components/HeroBanner.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+import ParallaxBanner from './ParallaxBanner';
+import {
+    DocumentArrowDownIcon,
+    CodeBracketIcon,
+    CpuChipIcon,
+    ServerStackIcon,
+    BeakerIcon,
+} from '@heroicons/react/24/solid';
+
+interface Props {
+    src: string;
+}
+
+export default function HeroBanner({ src }: Props) {
+    const [resumeAvailable, setResumeAvailable] = useState(false);
+    const techIcons = [CodeBracketIcon, CpuChipIcon, ServerStackIcon, BeakerIcon];
+
+    useEffect(() => {
+        fetch('/resume.pdf', { method: 'HEAD' })
+            .then(res => setResumeAvailable(res.ok))
+            .catch(() => setResumeAvailable(false));
+    }, []);
+
+    return (
+        <div className="relative">
+            <ParallaxBanner src={src} className="h-64 md:h-96" />
+            <div className="absolute inset-0 bg-gradient-to-br from-primary to-primary-dark opacity-80" />
+            <div className="absolute inset-0 flex flex-col items-center justify-center gap-4 text-white">
+                <h1 className="text-5xl font-extrabold">个人主页</h1>
+                <div className="flex flex-wrap justify-center gap-4 opacity-70">
+                    {techIcons.map((Icon, idx) => (
+                        <Icon key={idx} className="w-8 h-8" />
+                    ))}
+                </div>
+                {resumeAvailable && (
+                    <a
+                        href="/resume.pdf"
+                        download
+                        className="px-6 py-3 bg-white text-primary rounded-full font-semibold shadow-lg flex items-center gap-2"
+                    >
+                        <DocumentArrowDownIcon className="w-5 h-5" />
+                        下载简历
+                    </a>
+                )}
+                <p className="text-sm opacity-90">邮箱：you@example.com ｜ 电话：123-456-7890</p>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/components/TimelinePage.tsx
+++ b/frontend/src/components/TimelinePage.tsx
@@ -15,7 +15,7 @@ import {
 import { useNavigate } from 'react-router-dom';
 import { useState, type JSX } from 'react';
 import Markdown from './Markdown';
-import ParallaxBanner from './ParallaxBanner';
+import HeroBanner from './HeroBanner';
 
 const icons: Record<string, JSX.Element> = {
     FlagIcon: <FlagIcon className="w-6 h-6" />,
@@ -29,7 +29,7 @@ export default function TimelinePage() {
 
     return (
         <section className="parallax-wrapper min-h-screen bg-slate-50 dark:bg-slate-900 py-12 px-4">
-            {events[0].cover && <ParallaxBanner src={events[0].cover} />}
+            {events[0].cover && <HeroBanner src={events[0].cover} />}
 
             <motion.h1
                 className="text-4xl font-bold mb-6 text-slate-800 dark:text-slate-100"


### PR DESCRIPTION
## Summary
- implement `HeroBanner` component overlaying profile info on the timeline cover
- use this new hero in `TimelinePage`

## Testing
- `npm install`
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6853dd85a590832eb968d8de6a8b2249