### PR TITLE
Improve hero image

### DIFF
--- a/frontend/src/components/ParallaxBanner.tsx
+++ b/frontend/src/components/ParallaxBanner.tsx
@@ -11,7 +11,7 @@ interface ParallaxBannerProps {
 export default function ParallaxBanner({ src, className }: ParallaxBannerProps) {
     return (
         <div
-            className={`w-full h-64 md:h-96 object-cover bg-center bg-cover rounded-xl mb-10 shadow ${className || ''}`}
+            className={`w-full object-cover bg-center bg-cover rounded-xl mb-10 shadow ${className || ''}`}
             style={{
                 backgroundImage: `url(${src})`,
                 backgroundAttachment: 'fixed',

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -4,14 +4,9 @@ import ParallaxBanner from '../components/ParallaxBanner';
 export default function Home() {
     return (
         <div className="relative min-h-screen overflow-hidden text-white">
-            <ParallaxBanner src="/images/banner.jpg" className="h-64 md:h-96" />
+            <ParallaxBanner src="/images/profile-banner.jpg" className="h-screen" />
             <div className="absolute inset-0 bg-primary-dark/70" />
             <div className="absolute inset-0 flex flex-col items-center justify-center gap-6">
-                <img
-                    src="/images/profile.jpg"
-                    alt="个人照片"
-                    className="w-40 h-40 rounded-full object-cover shadow-lg"
-                />
                 <h1 className="text-5xl font-extrabold">个人主页</h1>
                 <Link
                     to="/timeline"


### PR DESCRIPTION
## Summary
- remove fixed height from `ParallaxBanner` so each page can control it
- use a full-screen banner on the home page instead of small avatar

## Testing
- `npm run lint`
- `npm run build`
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854043b1260832e948737a5f35d3d72