### PR TITLE
Add contain option for banner

### DIFF
--- a/frontend/src/components/ParallaxBanner.tsx
+++ b/frontend/src/components/ParallaxBanner.tsx
@@ -4,14 +4,15 @@ import React from 'react';
 
 // 1. props 类型声明（必须！）
 interface ParallaxBannerProps {
-    src: string;             // 背景图片地址
-    className?: string;      // 可选：自定义 class
+    src: string; // 背景图片地址
+    className?: string; // 可选：自定义 class
+    contain?: boolean; // 使用 contain 以完整显示图片
 }
 
-export default function ParallaxBanner({ src, className }: ParallaxBannerProps) {
+export default function ParallaxBanner({ src, className, contain }: ParallaxBannerProps) {
     return (
         <div
-            className={`w-full object-cover bg-center bg-cover rounded-xl mb-10 shadow ${className || ''}`}
+            className={`w-full bg-center rounded-xl mb-10 shadow ${contain ? 'bg-contain bg-no-repeat' : 'bg-cover'} ${className || ''}`}
             style={{
                 backgroundImage: `url(${src})`,
                 backgroundAttachment: 'fixed',

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -4,7 +4,7 @@ import ParallaxBanner from '../components/ParallaxBanner';
 export default function Home() {
     return (
         <div className="relative min-h-screen overflow-hidden text-white">
-            <ParallaxBanner src="/images/profile-banner.jpg" className="h-screen" />
+            <ParallaxBanner src="/images/profile-banner.jpg" className="h-screen" contain />
             <div className="absolute inset-0 bg-primary-dark/70" />
             <div className="absolute inset-0 flex flex-col items-center justify-center gap-6">
                 <h1 className="text-5xl font-extrabold">个人主页</h1>


### PR DESCRIPTION
## Summary
- add optional `contain` prop for `ParallaxBanner` so background images can be fully visible
- use this new option on the home page banner to avoid cropping

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6854ec347f48832e9371062524c81f62