### PR TITLE
Add image fit option to ParallaxBanner

### DIFF
--- a/frontend/src/components/ParallaxBanner.tsx
+++ b/frontend/src/components/ParallaxBanner.tsx
@@ -6,12 +6,15 @@ import React from 'react';
 interface ParallaxBannerProps {
     src: string;             // 背景图片地址
     className?: string;      // 可选：自定义 class
+    fit?: 'cover' | 'contain'; // 背景适应方式
 }
 
-export default function ParallaxBanner({ src, className }: ParallaxBannerProps) {
+export default function ParallaxBanner({ src, className, fit = 'cover' }: ParallaxBannerProps) {
     return (
         <div
-            className={`w-full object-cover bg-center bg-cover rounded-xl mb-10 shadow ${className || ''}`}
+            className={`w-full bg-center rounded-xl mb-10 shadow ${
+                fit === 'contain' ? 'bg-contain' : 'bg-cover'
+            } ${className || ''}`}
             style={{
                 backgroundImage: `url(${src})`,
                 backgroundAttachment: 'fixed',

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -4,7 +4,7 @@ import ParallaxBanner from '../components/ParallaxBanner';
 export default function Home() {
     return (
         <div className="relative min-h-screen overflow-hidden text-white">
-            <ParallaxBanner src="/images/profile-banner.jpg" className="h-screen" />
+            <ParallaxBanner src="/images/profile-banner.jpg" className="h-screen" fit="contain" />
             <div className="absolute inset-0 bg-primary-dark/40" />
             <div className="absolute inset-0 flex flex-col items-center justify-center gap-6">
                 <h1 className="text-5xl font-extrabold">个人主页</h1>


### PR DESCRIPTION
## Summary
- let `ParallaxBanner` accept a `fit` prop to choose between `cover` or `contain`
- use the new prop on the `Home` page so large images fit entirely

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685553c24148832e9cef49c04857480b