### PR TITLE
Fix repeating homepage hero image

### DIFF
--- a/frontend/src/components/ParallaxBanner.tsx
+++ b/frontend/src/components/ParallaxBanner.tsx
@@ -12,7 +12,7 @@ interface ParallaxBannerProps {
 export default function ParallaxBanner({ src, className, fit = 'cover' }: ParallaxBannerProps) {
     return (
         <div
-            className={`w-full bg-center rounded-xl mb-10 shadow ${
+            className={`w-full bg-center bg-no-repeat rounded-xl mb-10 shadow ${
                 fit === 'contain' ? 'bg-contain' : 'bg-cover'
             } ${className || ''}`}
             style={{

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -4,7 +4,12 @@ import ParallaxBanner from '../components/ParallaxBanner';
 export default function Home() {
     return (
         <div className="relative min-h-screen overflow-hidden text-white">
-            <ParallaxBanner src="/images/profile-banner.jpg" className="h-screen" fit="contain" />
+            {/* Use cover to ensure background doesn't repeat on larger screens */}
+            <ParallaxBanner
+                src="/images/profile-banner.jpg"
+                className="h-screen mb-0"
+                fit="cover"
+            />
             <div className="absolute inset-0 bg-primary-dark/40" />
             <div className="absolute inset-0 flex flex-col items-center justify-center gap-6">
                 <h1 className="text-5xl font-extrabold">个人主页</h1>


### PR DESCRIPTION
## Summary
- use `fit="cover"` for homepage hero

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68555799e154832e93d8bd178e6ab7a8