### PR TITLE
Fix artifact deprecation

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -51,7 +51,7 @@ jobs:
         run: dotnet build TimelineSite/TimelineSite.sln
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: frontend/dist
 


### PR DESCRIPTION
## Summary
- update workflow to `actions/upload-pages-artifact@v3`

## Testing
- `npm run lint`
- `npm ci`
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685567f43d74832e8bc52f822d8ecdd8