### PR TITLE
Fix base path for GitHub Pages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,7 +12,7 @@ export default function App() {
     const [dark, setDark] = useState(false);
 
     return (
-        <BrowserRouter>
+        <BrowserRouter basename="/TimelineSite">
             <div className={dark ? 'dark' : ''}>
                 {/* 亮／暗主题按钮 */}
                 <button

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,6 +2,7 @@
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({
+    base: '/TimelineSite/',
     plugins: [react()],
     server: {
         port: 5173,


### PR DESCRIPTION
## Summary
- set Vite base path so built assets load from `/TimelineSite/`
- configure React Router `BrowserRouter` with basename `/TimelineSite`

## Testing
- `npm run build`
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6855709d81a0832eaa5ea6197d644ca3