### PR TITLE
Fix image paths and add skills

### DIFF
--- a/frontend/src/components/HeroBanner.tsx
+++ b/frontend/src/components/HeroBanner.tsx
@@ -6,6 +6,11 @@ import {
     DevicePhoneMobileIcon,
     ServerIcon,
     CloudIcon,
+    CodeBracketSquareIcon,
+    PaintBrushIcon,
+    FilmIcon,
+    WrenchScrewdriverIcon,
+    CommandLineIcon,
 } from '@heroicons/react/24/solid';
 
 interface Props {
@@ -20,6 +25,11 @@ export default function HeroBanner({ src, overlayClassName }: Props) {
         { Icon: DevicePhoneMobileIcon, label: '移动应用' },
         { Icon: ServerIcon, label: '后端服务' },
         { Icon: CloudIcon, label: '云部署' },
+        { Icon: CodeBracketSquareIcon, label: 'React/Vue 组件化开发' },
+        { Icon: PaintBrushIcon, label: 'UI 图标设计' },
+        { Icon: FilmIcon, label: '视频剪辑与动效' },
+        { Icon: WrenchScrewdriverIcon, label: '工具链 Git · Docker · CI/CD' },
+        { Icon: CommandLineIcon, label: 'Python 数据脚本' },
     ];
 
     useEffect(() => {

--- a/frontend/src/data/events.ts
+++ b/frontend/src/data/events.ts
@@ -64,13 +64,10 @@ export const events: TimelineEvent[] = [
         title: '第一个个人网站',
         description: '最小可运行版本个人网站，有最基础的功能',
         icon: 'CommandLineIcon',   // Heroicons 名称，可省
-        cover: '/assets/parallax.jpg',    // 详情页横幅，可省
+        cover: '/images/profile-banner3.jpg',    // 详情页横幅，可省
         image: '/images/fi-web-project.png', // 只要加上 image 字段就行
         images: [
             '/images/fi-web-project1.png',
-            '/images/fi-web-project2.png',
-            '/images/fi-web-project3.png',
-            '/images/fi-web-project4.png',
         ],
     },
     {
@@ -79,7 +76,7 @@ export const events: TimelineEvent[] = [
         title: '项目',
         description: '各种小项目、不值一提，以后再放上来',
         icon: 'PuzzlePieceIcon',   // Heroicons 名称，可省
-        cover: '/assets/pic.jpg'    // 详情页横幅，可省
+        cover: '/images/profile-banner3.jpg'    // 详情页横幅，可省
     },
 ];
 


### PR DESCRIPTION
## Summary
- extend `HeroBanner` skill list with additional items
- fix incorrect image references in `events.ts`

## Testing
- `npm run lint`
- `npm run build`
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685575eda9e8832ea31c6ac6e6d61755