### PR TITLE
Fix parallax banner on mobile

### DIFF
--- a/frontend/src/components/ParallaxBanner.tsx
+++ b/frontend/src/components/ParallaxBanner.tsx
@@ -1,15 +1,38 @@
 ﻿// src/components/ParallaxBanner.tsx
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 // 1. props 类型声明（必须！）
 interface ParallaxBannerProps {
     src: string;             // 背景图片地址
     className?: string;      // 可选：自定义 class
     fit?: 'cover' | 'contain'; // 背景适应方式
+    disableFixed?: boolean;  // 在移动端禁用 fixed 背景
 }
 
-export default function ParallaxBanner({ src, className, fit = 'cover' }: ParallaxBannerProps) {
+export default function ParallaxBanner({ src, className, fit = 'cover', disableFixed }: ParallaxBannerProps) {
+    const [isCoarse, setIsCoarse] = useState(false);
+
+    useEffect(() => {
+        if (typeof window === 'undefined' || !window.matchMedia) return;
+        const mql = window.matchMedia('(pointer:coarse)');
+        const update = (e: MediaQueryList | MediaQueryListEvent) => setIsCoarse(e.matches);
+        update(mql);
+        if (mql.addEventListener) {
+            mql.addEventListener('change', update);
+            return () => mql.removeEventListener('change', update);
+        }
+        // Fallback for older browsers
+        const legacyMql = mql as unknown as {
+            addListener: (listener: (e: MediaQueryListEvent) => void) => void;
+            removeListener: (listener: (e: MediaQueryListEvent) => void) => void;
+        };
+        legacyMql.addListener(update);
+        return () => legacyMql.removeListener(update);
+    }, []);
+
+    const attachment = disableFixed || isCoarse ? 'scroll' : 'fixed';
+
     return (
         <div
             className={`w-full bg-center bg-no-repeat rounded-xl mb-10 shadow ${
@@ -17,7 +40,7 @@ export default function ParallaxBanner({ src, className, fit = 'cover' }: Parall
             } ${className || ''}`}
             style={{
                 backgroundImage: `url(${src})`,
-                backgroundAttachment: 'fixed',
+                backgroundAttachment: attachment,
             }}
             aria-label="banner"
         />


### PR DESCRIPTION
## Summary
- adjust `ParallaxBanner` to fall back to `background-attachment: scroll` on mobile devices
- allow disabling the fixed background via a prop

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68557f08d744832eba1e4320a0bd3107