### PR TITLE
Fix banner cropping on mobile

### DIFF
--- a/frontend/src/components/ParallaxBanner.tsx
+++ b/frontend/src/components/ParallaxBanner.tsx
@@ -33,11 +33,14 @@ export default function ParallaxBanner({ src, className, fit = 'cover', disableF
 
     const attachment = disableFixed || isCoarse ? 'scroll' : 'fixed';
 
+    const fitClass =
+        fit === 'contain' ? 'bg-contain' : 'bg-contain sm:bg-cover';
+
     return (
         <div
-            className={`w-full bg-center bg-no-repeat rounded-xl mb-10 shadow ${
-                fit === 'contain' ? 'bg-contain' : 'bg-cover'
-            } ${className || ''}`}
+            className={`w-full bg-center bg-no-repeat rounded-xl mb-10 shadow ${fitClass} ${
+                className || ''
+            }`}
             style={{
                 backgroundImage: `url(${src})`,
                 backgroundAttachment: attachment,


### PR DESCRIPTION
## Summary
- adjust ParallaxBanner to show full image on small screens

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6856310005b4832eae29181c73ba8731