### PR TITLE
Improve responsive layout

### DIFF
--- a/frontend/src/components/HeroBanner.tsx
+++ b/frontend/src/components/HeroBanner.tsx
@@ -47,12 +47,12 @@ export default function HeroBanner({ src, overlayClassName }: Props) {
                     overlayClassName || 'bg-gradient-to-br from-primary to-primary-dark opacity-80'
                 }`}
             />
-            <div className="absolute inset-0 flex flex-col items-center justify-center gap-4 text-white">
-                <h1 className="text-5xl font-extrabold">项目 技能</h1>
+            <div className="absolute inset-0 flex flex-col items-center justify-center gap-4 text-white px-4">
+                <h1 className="text-3xl md:text-5xl font-extrabold">项目 技能</h1>
                 <div className="flex flex-wrap justify-center gap-6 opacity-100">
                     {techIcons.map(({ Icon, label }, idx) => (
                         <div key={idx} className="flex flex-col items-center">
-                            <Icon className="w-8 h-8" />
+                            <Icon className="w-6 h-6 md:w-8 md:h-8" />
                             <span className="text-xs mt-1">{label}</span>
                         </div>
                     ))}

--- a/frontend/src/components/TimelinePage.tsx
+++ b/frontend/src/components/TimelinePage.tsx
@@ -16,7 +16,7 @@ import {
     PuzzlePieceIcon,
 } from '@heroicons/react/24/solid';
 import { useNavigate } from 'react-router-dom';
-import { useState, type JSX } from 'react';
+import { useState, useEffect, type JSX } from 'react';
 import Markdown from './Markdown';
 import HeroBanner from './HeroBanner';
 
@@ -32,6 +32,16 @@ const icons: Record<string, JSX.Element> = {
 export default function TimelinePage() {
     const navigate = useNavigate();
     const [searchTerm, setSearchTerm] = useState('');
+    const [layout, setLayout] = useState<'1-column' | '2-columns'>('2-columns');
+
+    useEffect(() => {
+        const updateLayout = () => {
+            setLayout(window.innerWidth < 768 ? '1-column' : '2-columns');
+        };
+        updateLayout();
+        window.addEventListener('resize', updateLayout);
+        return () => window.removeEventListener('resize', updateLayout);
+    }, []);
 
     return (
         <section className="parallax-wrapper min-h-screen bg-slate-50 dark:bg-slate-900 py-12 px-4">
@@ -62,6 +72,7 @@ export default function TimelinePage() {
                 animate
                 lineColor="#0ea5e9"
                 className="timeline relative snap-y snap-mandatory"
+                layout={layout}
             >
                 {events
                     .filter(e =>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -11,8 +11,8 @@ export default function Home() {
                 fit="cover"
             />
             <div className="absolute inset-0 bg-primary-dark/40" />
-            <div className="absolute inset-0 flex flex-col items-center justify-center gap-6">
-                <h1 className="text-5xl font-extrabold">个人主页</h1>
+            <div className="absolute inset-0 flex flex-col items-center justify-center gap-6 px-4 text-center">
+                <h1 className="text-4xl md:text-5xl font-extrabold">个人主页</h1>
                 <Link
                     to="/timeline"
                     className="px-6 py-3 bg-primary-dark/80 rounded-full font-semibold shadow-lg hover:scale-105 transition-transform"


### PR DESCRIPTION
## Summary
- tweak hero banner layout
- make home page heading responsive
- adjust timeline to switch layouts based on screen width

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6859258edde8832e96962447311beb8a